### PR TITLE
Remove unused file which generates psr-0 error.

### DIFF
--- a/library/HTMLPurifier/Language/classes/en-x-test.php
+++ b/library/HTMLPurifier/Language/classes/en-x-test.php
@@ -1,9 +1,0 @@
-<?php
-
-// private class for unit testing
-
-class HTMLPurifier_Language_en_x_test extends HTMLPurifier_Language
-{
-}
-
-// vim: et sw=4 sts=4


### PR DESCRIPTION
Error details:

Deprecation Notice: Class HTMLPurifier_Language_en_x_test located in ./vendor/ezyang/htmlpurifier/library/HTMLPurifier/Language/classes/en-x-test.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201